### PR TITLE
Fix missing useMediaQuery hook

### DIFF
--- a/components/ui/use-mobile.tsx
+++ b/components/ui/use-mobile.tsx
@@ -2,18 +2,25 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+export function useMediaQuery(query: string) {
+  const getMatch = React.useCallback(() => {
+    if (typeof window === "undefined") return false
+    return window.matchMedia(query).matches
+  }, [query])
+
+  const [matches, setMatches] = React.useState(getMatch)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
+    const mql = window.matchMedia(query)
+    const onChange = () => setMatches(getMatch())
+    onChange()
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
-  }, [])
+  }, [query, getMatch])
 
-  return !!isMobile
+  return matches
+}
+
+export function useIsMobile() {
+  return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
 }

--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -2,18 +2,25 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+export function useMediaQuery(query: string) {
+  const getMatch = React.useCallback(() => {
+    if (typeof window === "undefined") return false
+    return window.matchMedia(query).matches
+  }, [query])
+
+  const [matches, setMatches] = React.useState(getMatch)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
+    const mql = window.matchMedia(query)
+    const onChange = () => setMatches(getMatch())
+    onChange()
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
-  }, [])
+  }, [query, getMatch])
 
-  return !!isMobile
+  return matches
+}
+
+export function useIsMobile() {
+  return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
 }


### PR DESCRIPTION
## Summary
- add a general `useMediaQuery` hook and update `useIsMobile`
- mirror the new hook in the UI utilities

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_6849c377b958832cb3619ef7b8b9ff4f