### PR TITLE
Add user creation script and restore DB utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,13 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "check-env": "ts-node-esm scripts/check-env.ts",
+    "setup-db": "ts-node-esm scripts/setup-database.ts",
+    "test-db": "ts-node-esm scripts/test-db-connection.ts",
+    "seed-admin": "ts-node-esm scripts/seed-admin-user.ts",
+    "create-user": "ts-node-esm scripts/create-user.ts",
+    "setup": "ts-node-esm scripts/setup.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -66,6 +72,7 @@
     "@types/react-dom": "^19",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10.9.1"
   }
 }

--- a/scripts/create-user.ts
+++ b/scripts/create-user.ts
@@ -1,0 +1,62 @@
+import { hash } from "bcrypt";
+import { query, transaction } from "@/lib/db";
+import dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+
+interface Options {
+  email?: string;
+  password?: string;
+  fullName?: string;
+  role?: string;
+}
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2);
+  const opts: Options = {};
+  for (let i = 0; i < args.length; i += 2) {
+    const key = args[i].replace(/^--/, "");
+    opts[key as keyof Options] = args[i + 1];
+  }
+  return opts;
+}
+
+async function createUser(opts: Options) {
+  const { email, password, fullName, role = "user" } = opts;
+  if (!email || !password) {
+    console.error(
+      "Usage: npm run create-user -- --email <email> --password <password> [--fullName <Full Name>] [--role <role>]"
+    );
+    process.exit(1);
+  }
+
+  console.log(`Checking if user ${email} exists...`);
+  const existing = await query("SELECT 1 FROM users WHERE email = $1", [email]);
+  if (existing.rows.length > 0) {
+    console.log("User already exists.");
+    return;
+  }
+
+  console.log("Creating user...");
+  const hashed = await hash(password, 10);
+  await transaction(async (client) => {
+    const res = await client.query(
+      "INSERT INTO users (email, password_hash, full_name, role) VALUES ($1, $2, $3, $4) RETURNING id",
+      [email, hashed, fullName || email, role]
+    );
+    const userId = res.rows[0].id;
+    await client.query("INSERT INTO user_profiles (user_id) VALUES ($1)", [userId]);
+  });
+
+  console.log(`User ${email} created with role ${role}.`);
+}
+
+createUser(parseArgs())
+  .then(() => {
+    console.log("Done.");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("Error creating user:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- restore `lib/db.ts` with connection pooling utilities
- add `create-user.ts` for creating accounts with configurable role
- add npm scripts for setup and database tools
- include `ts-node` as dev dependency for TypeScript scripts

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run test-db` *(fails: ts-node-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a43984f90832c9990f8596f3c68b7