### PR TITLE
Add Unity client project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ package-lock.json
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+# Unity
+/Unity/Library/
+/Unity/Logs/
+/Unity/Temp/
+/Unity/Build/
+/Unity/obj/

--- a/Unity/Assets/Scripts/WebSocketClient.cs
+++ b/Unity/Assets/Scripts/WebSocketClient.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class WebSocketClient : MonoBehaviour
+{
+    private ClientWebSocket _socket;
+
+    [Tooltip("Conversation identifier appended to the websocket URL")] 
+    public string ConversationId = "1";
+
+    async void Start()
+    {
+        string baseUrl = Environment.GetEnvironmentVariable("WEBSOCKET_URL");
+        if (string.IsNullOrEmpty(baseUrl))
+        {
+            baseUrl = "ws://localhost:8000/ws/conversations/";
+        }
+
+        string url = $"{baseUrl}{ConversationId}/";
+        _socket = new ClientWebSocket();
+        await _socket.ConnectAsync(new Uri(url), CancellationToken.None);
+        Debug.Log($"Connected to {url}");
+
+        _ = ReceiveLoop();
+    }
+
+    public async Task Send(string message)
+    {
+        if (_socket == null || _socket.State != WebSocketState.Open) return;
+        byte[] data = Encoding.UTF8.GetBytes(message);
+        var buffer = new ArraySegment<byte>(data);
+        await _socket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
+    }
+
+    private async Task ReceiveLoop()
+    {
+        var buffer = new ArraySegment<byte>(new byte[1024]);
+        while (_socket.State == WebSocketState.Open)
+        {
+            WebSocketReceiveResult result = await _socket.ReceiveAsync(buffer, CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                break;
+            }
+            else
+            {
+                string message = Encoding.UTF8.GetString(buffer.Array, 0, result.Count);
+                Debug.Log($"Message received: {message}");
+            }
+        }
+    }
+
+    async void OnDestroy()
+    {
+        if (_socket != null && _socket.State == WebSocketState.Open)
+        {
+            await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Component destroyed", CancellationToken.None);
+        }
+    }
+}

--- a/Unity/Packages/manifest.json
+++ b/Unity/Packages/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "llm-sandbox-unity",
+  "version": "0.1.0",
+  "dependencies": {
+    "com.unity.inputsystem": "1.6.1",
+    "com.unity.textmeshpro": "3.0.6",
+    "com.unity.timeline": "1.8.1",
+    "com.unity.modules.unitywebrequest": "1.0.0"
+  },
+  "registry": "https://packages.unity.com"
+}

--- a/Unity/ProjectSettings/ProjectVersion.txt
+++ b/Unity/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,1 @@
+m_EditorVersion: 2021.3.14f1

--- a/Unity/README.md
+++ b/Unity/README.md
@@ -1,0 +1,38 @@
+# Unity Client
+
+This directory contains a minimal Unity project that connects to the Django websocket endpoint used by the LLM Sandbox backend.
+
+## Structure
+
+- `Assets/Scripts/WebSocketClient.cs` – MonoBehaviour component establishing the websocket connection.
+- `Packages/manifest.json` – Unity package manifest.
+- `ProjectSettings/ProjectVersion.txt` – Unity editor version file.
+
+## Configuration
+
+The websocket endpoint base URL is read from the environment variable `WEBSOCKET_URL`.
+If this variable is not defined, the script defaults to `ws://localhost:8000/ws/conversations/`.
+
+At runtime the component appends the `ConversationId` value to this base URL to produce the final socket path:
+
+```
+<WEBSOCKET_URL><ConversationId>/
+```
+
+Set the environment variable before launching the Unity editor or when running the built application:
+
+```bash
+export WEBSOCKET_URL=ws://example.com/ws/conversations/
+```
+
+You can modify `ConversationId` via the inspector on the `WebSocketClient` component.
+
+## Building
+
+1. Open **Unity Hub**.
+2. Click **Add** and select the `Unity/` directory.
+3. Open the project using Unity 2021.3 LTS or a newer version.
+4. Create a scene containing an empty GameObject and attach the `WebSocketClient` script.
+5. Build the project using **File > Build Settings** for your target platform.
+
+The built application will attempt to connect to the websocket endpoint on startup.


### PR DESCRIPTION
## Summary
- ignore generated Unity directories
- add minimal Unity project with websocket support
- document Unity build steps and environment-based websocket configuration

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684fa4e869b0832c961a759f765fbd90