### PR TITLE
Add missing API endpoints

### DIFF
--- a/api/ai/route.ts
+++ b/api/ai/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { prompt, systemPrompt } = await req.json();
+    if (!prompt) {
+      return NextResponse.json({ error: "Prompt is required" }, { status: 400 });
+    }
+
+    const { text } = await generateText({
+      model: openai("gpt-4o"),
+      prompt,
+      system: systemPrompt || "You are a helpful assistant.",
+    });
+
+    return NextResponse.json({ text });
+  } catch (error) {
+    console.error("Error generating text:", error);
+    return NextResponse.json({ error: "Failed to generate text" }, { status: 500 });
+  }
+}

--- a/app/api/templates/route.ts
+++ b/app/api/templates/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { searchTemplates } from "@/lib/template-service";
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const category = searchParams.get("category") || undefined;
+    const q = searchParams.get("q") || undefined;
+    const includePublic = searchParams.get("includePublic") !== "false";
+    const tags = searchParams.getAll("tag");
+
+    const { templates } = await searchTemplates({
+      category,
+      query: q,
+      tags: tags.length > 0 ? tags : undefined,
+      includePublic,
+    });
+
+    return NextResponse.json(templates);
+  } catch (error) {
+    console.error("Error fetching templates:", error);
+    return NextResponse.json({ error: "Failed to fetch templates" }, { status: 500 });
+  }
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { query } from "@/lib/db";
+
+export async function GET() {
+  try {
+    const result = await query(
+      `SELECT id, email, full_name, role, is_active, created_at, updated_at FROM users ORDER BY created_at DESC`
+    );
+    return NextResponse.json(result.rows);
+  } catch (error) {
+    console.error("Error fetching users:", error);
+    return NextResponse.json({ error: "Failed to fetch users" }, { status: 500 });
+  }
+}

--- a/types/database.ts
+++ b/types/database.ts
@@ -13,10 +13,33 @@ export interface Todo {
 
 // User types
 export interface User {
-  id: number
-  username: string
+  id: string
   email: string
+  full_name: string
   role: string
+  is_active: boolean
   created_at: string
   updated_at: string
+}
+
+export interface Template {
+  id: string
+  name: string
+  description: string | null
+  category: string
+  content: unknown
+  tags: string[]
+  created_by: string | null
+  is_public: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface File {
+  id: string
+  name: string
+  type: string
+  size: number
+  url: string
+  created_at: string
 }


### PR DESCRIPTION
## Summary
- implement missing `/api/users` endpoint
- implement missing `/api/templates` endpoint
- add `/api/ai` route for AI prompt
- update type definitions for `User`, `Template`, and `File`

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68504fca39b0832c8be0e5f983e469a6