### PR TITLE
Add password reset and admin features

### DIFF
--- a/admin/page.tsx
+++ b/admin/page.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useSession } from "next-auth/react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { AlertCircle } from "lucide-react"
+
+export default function AdminPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [fullName, setFullName] = useState("")
+  const [password, setPassword] = useState("")
+  const [role, setRole] = useState("user")
+  const [message, setMessage] = useState("")
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    if (status === "loading") return
+    if (!session || session.user.role !== "admin") {
+      router.push("/dashboard")
+    }
+  }, [status, session, router])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setMessage("")
+    setError("")
+    const res = await fetch("/api/admin/add-user", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, fullName, role }),
+    })
+    if (res.ok) {
+      setMessage("User created")
+      setEmail("")
+      setFullName("")
+      setPassword("")
+    } else {
+      const data = await res.json()
+      setError(data.error || "Failed")
+    }
+  }
+
+  if (status === "loading") {
+    return <p className="p-4">Loading...</p>
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <Card className="max-w-lg mx-auto">
+        <CardHeader>
+          <CardTitle>Admin - Add User</CardTitle>
+          <CardDescription>Create a new user account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {message && (
+            <Alert className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="fullName">Full Name</Label>
+              <Input id="fullName" value={fullName} onChange={(e) => setFullName(e.target.value)} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                8+ characters, one uppercase, one number, one special character
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="role">Role</Label>
+              <select
+                id="role"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+              >
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <Button type="submit" className="w-full">
+              Create User
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/api/admin/add-user/route.ts
+++ b/api/admin/add-user/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { query, transaction } from "@/lib/db"
+import { hash } from "bcrypt"
+import { getServerSession } from "next-auth/next"
+import { authOptions } from "@/lib/auth"
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z
+    .string()
+    .min(8)
+    .regex(/^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).+$/),
+  fullName: z.string().min(2),
+  role: z.enum(["admin", "user"]).default("user"),
+})
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 })
+  }
+
+  try {
+    const body = await req.json()
+    const result = schema.safeParse(body)
+    if (!result.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+    }
+    const { email, password, fullName, role } = result.data
+    const existing = await query("SELECT id FROM users WHERE email = $1", [email])
+    if (existing.rows.length > 0) {
+      return NextResponse.json({ error: "User exists" }, { status: 400 })
+    }
+    const hashed = await hash(password, 10)
+    const res = await transaction(async (client) => {
+      const result = await client.query(
+        "INSERT INTO users (email, password_hash, full_name, role) VALUES ($1,$2,$3,$4) RETURNING id",
+        [email, hashed, fullName, role]
+      )
+      await client.query("INSERT INTO user_profiles (user_id) VALUES ($1)", [result.rows[0].id])
+      return result.rows[0]
+    })
+    return NextResponse.json({ id: res.id })
+  } catch (err) {
+    console.error("add-user error", err)
+    return NextResponse.json({ error: "Server error" }, { status: 500 })
+  }
+}

--- a/api/admin/reset-user-password/route.ts
+++ b/api/admin/reset-user-password/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { query } from "@/lib/db"
+import { hash } from "bcrypt"
+import { getServerSession } from "next-auth/next"
+import { authOptions } from "@/lib/auth"
+
+const schema = z.object({
+  userId: z.string().uuid(),
+  password: z
+    .string()
+    .min(8)
+    .regex(/^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).+$/),
+})
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 })
+  }
+
+  try {
+    const body = await req.json()
+    const result = schema.safeParse(body)
+    if (!result.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+    }
+
+    const { userId, password } = result.data
+    const hashed = await hash(password, 10)
+    await query("UPDATE users SET password_hash = $1 WHERE id = $2", [hashed, userId])
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error("reset-user-password error", err)
+    return NextResponse.json({ error: "Server error" }, { status: 500 })
+  }
+}

--- a/api/auth/request-password-reset/route.ts
+++ b/api/auth/request-password-reset/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { query } from "@/lib/db"
+import { randomUUID } from "crypto"
+
+const schema = z.object({
+  email: z.string().email(),
+})
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+    const result = schema.safeParse(body)
+    if (!result.success) {
+      return NextResponse.json({ error: "Invalid email" }, { status: 400 })
+    }
+
+    const { email } = result.data
+    const userRes = await query("SELECT id FROM users WHERE email = $1", [email])
+    if (userRes.rows.length === 0) {
+      // Always respond with success to prevent user enumeration
+      return NextResponse.json({ message: "If that email exists, a reset link was sent." })
+    }
+
+    const token = randomUUID()
+    const expires = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
+    await query(
+      "INSERT INTO password_reset_tokens (user_id, token, expires_at) VALUES ($1, $2, $3)",
+      [userRes.rows[0].id, token, expires]
+    )
+
+    console.log(`Password reset token for ${email}: ${token}`)
+
+    return NextResponse.json({ message: "If that email exists, a reset link was sent." })
+  } catch (err) {
+    console.error("request-password-reset error", err)
+    return NextResponse.json({ error: "Server error" }, { status: 500 })
+  }
+}

--- a/api/auth/reset-password/route.ts
+++ b/api/auth/reset-password/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { query, transaction } from "@/lib/db"
+import { hash } from "bcrypt"
+
+const schema = z.object({
+  token: z.string().uuid(),
+  password: z
+    .string()
+    .min(8)
+    .regex(/^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).+$/),
+})
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+    const result = schema.safeParse(body)
+    if (!result.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+    }
+
+    const { token, password } = result.data
+    const tokenRes = await query(
+      "SELECT user_id, expires_at FROM password_reset_tokens WHERE token = $1",
+      [token]
+    )
+    if (tokenRes.rows.length === 0) {
+      return NextResponse.json({ error: "Invalid token" }, { status: 400 })
+    }
+    const { user_id, expires_at } = tokenRes.rows[0]
+    if (new Date(expires_at) < new Date()) {
+      await query("DELETE FROM password_reset_tokens WHERE token = $1", [token])
+      return NextResponse.json({ error: "Token expired" }, { status: 400 })
+    }
+
+    const hashed = await hash(password, 10)
+    await transaction(async (client) => {
+      await client.query("UPDATE users SET password_hash = $1 WHERE id = $2", [hashed, user_id])
+      await client.query("DELETE FROM password_reset_tokens WHERE token = $1", [token])
+    })
+
+    return NextResponse.json({ message: "Password updated" })
+  } catch (err) {
+    console.error("reset-password error", err)
+    return NextResponse.json({ error: "Server error" }, { status: 500 })
+  }
+}

--- a/dashboard/page.tsx
+++ b/dashboard/page.tsx
@@ -1,102 +1,72 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import EnvChecker from "@/components/env-checker"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 
 export default function DashboardPage() {
   return (
     <div className="container mx-auto py-8">
-      <h1 className="text-3xl font-bold mb-6">LLM Sandbox Dashboard</h1>
+      <h1 className="text-3xl font-bold mb-6">Dealership Dashboard</h1>
 
-      <div className="grid gap-6">
-        <EnvChecker />
-
-        <Card className="mb-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <Card>
           <CardHeader>
-            <CardTitle>Dashboard Overview</CardTitle>
-            <CardDescription>Welcome to the LLM Sandbox</CardDescription>
+            <CardTitle>Inventory Management</CardTitle>
+            <CardDescription>Manage new and used vehicles</CardDescription>
           </CardHeader>
           <CardContent>
-            <p>
-              This dashboard provides tools to manage your LLM Sandbox environment. Check your environment configuration
-              above to ensure everything is set up correctly.
-            </p>
-            <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
-              <Button asChild variant="outline">
-                <Link href="/sandbox">Launch Sandbox</Link>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href="/templates">Browse Templates</Link>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href="/settings">Settings</Link>
-              </Button>
-            </div>
+            <Button asChild variant="outline" className="w-full">
+              <Link href="/inventory">View Inventory</Link>
+            </Button>
           </CardContent>
         </Card>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Quick Start</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ol className="list-decimal list-inside space-y-2">
-                <li>Check your environment variables</li>
-                <li>Configure your database connection</li>
-                <li>Create your first agent</li>
-                <li>Start a conversation</li>
-              </ol>
-            </CardContent>
-          </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Sales</CardTitle>
+            <CardDescription>Track leads and finalize deals</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline" className="w-full">
+              <Link href="/sales">Sales Portal</Link>
+            </Button>
+          </CardContent>
+        </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Resources</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-2">
-                <li>
-                  <a href="https://github.com/yourusername/llm-sandbox" className="text-blue-500 hover:underline">
-                    GitHub Repository
-                  </a>
-                </li>
-                <li>
-                  <a href="https://docs.example.com/llm-sandbox" className="text-blue-500 hover:underline">
-                    Documentation
-                  </a>
-                </li>
-                <li>
-                  <a href="https://discord.gg/example" className="text-blue-500 hover:underline">
-                    Community Discord
-                  </a>
-                </li>
-              </ul>
-            </CardContent>
-          </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Service Department</CardTitle>
+            <CardDescription>Schedule and manage service orders</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline" className="w-full">
+              <Link href="/service">Service Desk</Link>
+            </Button>
+          </CardContent>
+        </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>System Status</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2">
-                <div className="flex justify-between">
-                  <span>Database:</span>
-                  <span className="text-green-500">Connected</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Authentication:</span>
-                  <span className="text-green-500">Active</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>LLM API:</span>
-                  <span className="text-green-500">Available</span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Customer Management</CardTitle>
+            <CardDescription>View and edit customer records</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline" className="w-full">
+              <Link href="/customers">Customer Database</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Reporting</CardTitle>
+            <CardDescription>Review performance metrics</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline" className="w-full">
+              <Link href="/reports">Reports</Link>
+            </Button>
+          </CardContent>
+        </Card>
       </div>
     </div>
   )

--- a/forgot-password/page.tsx
+++ b/forgot-password/page.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { AlertCircle } from "lucide-react"
+
+export default function ForgotPasswordPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [success, setSuccess] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError("")
+    setSuccess("")
+    const res = await fetch("/api/auth/request-password-reset", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    })
+    if (res.ok) {
+      setSuccess("If that email exists, a reset link was sent.")
+    } else {
+      const data = await res.json()
+      setError(data.error || "Request failed")
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl font-bold">Forgot Password</CardTitle>
+          <CardDescription>Enter your email to receive a reset link</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {success && (
+            <Alert className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{success}</AlertDescription>
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            </div>
+            <Button type="submit" className="w-full">
+              Send reset link
+            </Button>
+          </form>
+        </CardContent>
+        <CardFooter className="text-sm text-center">
+          <Button variant="link" onClick={() => router.push("/login")}>Back to login</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/login/page.tsx
+++ b/login/page.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useState } from "react"
+import { signIn } from "next-auth/react"
+import { useSearchParams, useRouter } from "next/navigation"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { AlertCircle } from "lucide-react"
+
+export default function LoginPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
+  const [error, setError] = useState("")
+  const registered = searchParams.get("registered")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError("")
+    const res = await signIn("credentials", {
+      redirect: false,
+      email,
+      password,
+    })
+    if (res?.error) {
+      setError("Invalid email or password")
+    } else {
+      router.push("/dashboard")
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl font-bold">Sign in to your account</CardTitle>
+          <CardDescription>Enter your email and password to sign in</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {registered && (
+            <Alert className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>Registration successful. Please sign in.</AlertDescription>
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-2 top-2 text-sm"
+                >
+                  {showPassword ? "Hide" : "Show"}
+                </button>
+              </div>
+            </div>
+            <Button type="submit" className="w-full">
+              Sign in
+            </Button>
+          </form>
+        </CardContent>
+        <CardFooter className="flex flex-col space-y-4">
+          <div className="flex justify-between w-full text-sm">
+            <Link href="/forgot-password" className="text-primary hover:underline">
+              Forgot password?
+            </Link>
+            <Link href="/register" className="text-primary hover:underline">
+              Create account
+            </Link>
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,8 @@ export async function middleware(request: NextRequest) {
     path === "/" ||
     path === "/login" ||
     path === "/register" ||
+    path === "/forgot-password" ||
+    path === "/reset-password" ||
     path === "/setup" ||
     path.startsWith("/auth/") ||
     path.startsWith("/api/auth/")
@@ -29,8 +31,12 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(url)
   }
 
-  if (token && (path === "/login" || path === "/register")) {
+  if (token && (path === "/login" || path === "/register" || path === "/forgot-password" || path === "/reset-password")) {
     // Redirect to dashboard if trying to access login/register while logged in
+    return NextResponse.redirect(new URL("/dashboard", request.url))
+  }
+
+  if (token && path.startsWith("/admin") && token.role !== "admin") {
     return NextResponse.redirect(new URL("/dashboard", request.url))
   }
 
@@ -49,7 +55,10 @@ export const config = {
     "/templates/:path*",
     "/analytics/:path*",
     "/sandbox/:path*",
+    "/admin/:path*",
     "/login",
     "/register",
+    "/forgot-password",
+    "/reset-password",
   ],
 }

--- a/reset-password/page.tsx
+++ b/reset-password/page.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { AlertCircle } from "lucide-react"
+
+export default function ResetPasswordPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token") || ""
+
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError("")
+    setSuccess("")
+    if (password !== confirm) {
+      setError("Passwords do not match")
+      return
+    }
+    const res = await fetch("/api/auth/reset-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, password }),
+    })
+    if (res.ok) {
+      setSuccess("Password updated. You can now sign in.")
+    } else {
+      const data = await res.json()
+      setError(data.error || "Reset failed")
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl font-bold">Reset Password</CardTitle>
+          <CardDescription>Enter your new password</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {success && (
+            <Alert className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{success}</AlertDescription>
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="password">New Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Password must be at least 8 characters and include uppercase, number and special character.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirm">Confirm Password</Label>
+              <Input id="confirm" type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required />
+            </div>
+            <Button type="submit" className="w-full">
+              Reset Password
+            </Button>
+          </form>
+        </CardContent>
+        <CardFooter className="text-sm text-center">
+          <Button variant="link" onClick={() => router.push("/login")}>Back to login</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/scripts/setup-database.ts
+++ b/scripts/setup-database.ts
@@ -51,6 +51,17 @@ async function setupDatabase() {
     `)
     console.log("✅ User profiles table created.")
 
+    // Password Reset Tokens Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS password_reset_tokens (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+        token UUID NOT NULL,
+        expires_at TIMESTAMP WITH TIME ZONE NOT NULL
+      );
+    `)
+    console.log("✅ Password reset tokens table created.")
+
     // Agents Table
     await query(`
       CREATE TABLE IF NOT EXISTS agents (


### PR DESCRIPTION
## Summary
- implement dealership dashboard
- add login, forgot password and reset password pages
- create password reset token table
- support password reset flows via API
- create admin API endpoints and page
- update middleware for new routes

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_687518b07c08832c9b49370da18b02e2