### PR TITLE
Add deal management workspace with PDF support

### DIFF
--- a/app/api/deals/[dealId]/documents/[documentId]/route.ts
+++ b/app/api/deals/[dealId]/documents/[documentId]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server"
+import { getDealDocumentBinary } from "@/lib/deal-service"
+
+interface Params {
+  params: { dealId: string; documentId: string }
+}
+
+export async function GET(request: Request, { params }: Params) {
+  try {
+    const document = await getDealDocumentBinary(params.dealId, params.documentId)
+    return new NextResponse(document.pdfData, {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${document.fileName}"`,
+        "Content-Length": document.pdfData.length.toString(),
+      },
+    })
+  } catch (error) {
+    console.error("Failed to download deal document", error)
+    return NextResponse.json({ error: "Document not found" }, { status: 404 })
+  }
+}

--- a/app/api/deals/[dealId]/documents/route.ts
+++ b/app/api/deals/[dealId]/documents/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server"
+import { generateDealDocument } from "@/lib/deal-service"
+
+interface Params {
+  params: { dealId: string }
+}
+
+export async function POST(req: Request, { params }: Params) {
+  try {
+    const body = await req.json()
+    const document = await generateDealDocument(params.dealId, body)
+    return NextResponse.json(document)
+  } catch (error) {
+    console.error("Failed to generate deal document", error)
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Failed to generate deal document" }, { status: 500 })
+  }
+}

--- a/app/api/deals/[dealId]/route.ts
+++ b/app/api/deals/[dealId]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server"
+import { getDeal } from "@/lib/deal-service"
+
+interface Params {
+  params: { dealId: string }
+}
+
+export async function GET(request: Request, { params }: Params) {
+  try {
+    const result = await getDeal(params.dealId)
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error("Failed to fetch deal", error)
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ error: "Failed to fetch deal" }, { status: 500 })
+  }
+}

--- a/app/api/deals/route.ts
+++ b/app/api/deals/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { listDeals, saveDeal } from "@/lib/deal-service"
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const storeId = searchParams.get("storeId")
+    if (!storeId) {
+      return NextResponse.json({ error: "storeId query parameter is required" }, { status: 400 })
+    }
+    const customerId = searchParams.get("customerId") ?? undefined
+    const deals = await listDeals({ storeId, customerId })
+    return NextResponse.json(deals)
+  } catch (error) {
+    console.error("Failed to list deals", error)
+    return NextResponse.json({ error: "Failed to list deals" }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+    const result = await saveDeal(body)
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error("Failed to save deal", error)
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Failed to save deal" }, { status: 500 })
+  }
+}

--- a/app/deals/page.tsx
+++ b/app/deals/page.tsx
@@ -1,0 +1,874 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import { Separator } from "@/components/ui/separator"
+import { toast } from "@/components/ui/use-toast"
+import {
+  calculateScenarioFinancials,
+  formatCurrency,
+  type ScenarioFinancials,
+} from "@/lib/deal-calculations"
+
+interface ScenarioFormState {
+  scenarioType: "cash" | "finance" | "lease"
+  price: number
+  downPayment: number
+  termMonths?: number
+  apr?: number
+  moneyFactor?: number
+  residualValue?: number
+  feesTotal: number
+  taxRate: number
+}
+
+interface DealScenario {
+  id: string
+  scenarioType: "cash" | "finance" | "lease"
+  version: number
+  price: number
+  downPayment: number
+  termMonths: number | null
+  apr: number | null
+  moneyFactor: number | null
+  residualValue: number | null
+  payment: number | null
+  fees: Record<string, unknown>
+  taxes: Record<string, unknown>
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
+interface DealDocumentSummary {
+  id: string
+  dealId: string
+  scenarioId: string | null
+  documentType: string
+  fileName: string
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
+interface DealResponse {
+  deal: {
+    id: string
+    storeId: string
+    customerId: string | null
+    title: string
+    status: string
+    basePrice: number
+    vehicle: Record<string, unknown>
+    notes?: string | null
+    createdAt: string
+    updatedAt: string
+  }
+  store: {
+    id: string
+    name: string
+    contactEmail: string | null
+    contactPhone: string | null
+    address: string | null
+    settings: Record<string, unknown>
+  }
+  customer: {
+    id: string
+    firstName: string
+    lastName: string
+    email: string | null
+    phone: string | null
+    profile: Record<string, unknown>
+  } | null
+  scenarios: DealScenario[]
+  documents: DealDocumentSummary[]
+  calculations?: Record<string, ScenarioFinancials>
+}
+
+type DealSummary = DealResponse["deal"] & {
+  storeName: string
+  customerName: string | null
+  scenarios: DealScenario[]
+  documents: DealDocumentSummary[]
+}
+
+const defaultScenarios: ScenarioFormState[] = [
+  {
+    scenarioType: "cash",
+    price: 45000,
+    downPayment: 45000,
+    feesTotal: 495,
+    taxRate: 7.5,
+  },
+  {
+    scenarioType: "finance",
+    price: 45000,
+    downPayment: 5000,
+    termMonths: 72,
+    apr: 5.5,
+    feesTotal: 795,
+    taxRate: 7.5,
+  },
+  {
+    scenarioType: "lease",
+    price: 45000,
+    downPayment: 3000,
+    termMonths: 36,
+    moneyFactor: 0.0021,
+    residualValue: 26000,
+    feesTotal: 895,
+    taxRate: 7.5,
+  },
+]
+
+function toNumber(value: string, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export default function DealsWorkspace() {
+  const [storeId, setStoreId] = useState("")
+  const [storeName, setStoreName] = useState("")
+  const [storeEmail, setStoreEmail] = useState("")
+  const [storePhone, setStorePhone] = useState("")
+  const [storeAddress, setStoreAddress] = useState("")
+  const [storePresetName, setStorePresetName] = useState("Default")
+  const [storePresetDefault, setStorePresetDefault] = useState(true)
+
+  const [customerId, setCustomerId] = useState("")
+  const [customerFirstName, setCustomerFirstName] = useState("")
+  const [customerLastName, setCustomerLastName] = useState("")
+  const [customerEmail, setCustomerEmail] = useState("")
+  const [customerPhone, setCustomerPhone] = useState("")
+  const [customerPresetName, setCustomerPresetName] = useState("Preferred")
+
+  const [dealTitle, setDealTitle] = useState("New Vehicle Proposal")
+  const [basePrice, setBasePrice] = useState(45000)
+  const [vehicleYear, setVehicleYear] = useState("")
+  const [vehicleMake, setVehicleMake] = useState("")
+  const [vehicleModel, setVehicleModel] = useState("")
+  const [vehicleTrim, setVehicleTrim] = useState("")
+  const [vehicleVin, setVehicleVin] = useState("")
+  const [dealNotes, setDealNotes] = useState("")
+
+  const [scenarios, setScenarios] = useState<ScenarioFormState[]>(defaultScenarios)
+  const [currentDeal, setCurrentDeal] = useState<DealResponse | null>(null)
+  const [dealHistory, setDealHistory] = useState<DealSummary[]>([])
+  const [isSaving, setIsSaving] = useState(false)
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
+
+  const scenarioCalculations = useMemo(() => {
+    return scenarios.reduce<Record<string, { result: ScenarioFinancials | null; error: string | null }>>(
+      (acc, scenario) => {
+        try {
+          const taxes = Number.isFinite(scenario.taxRate) ? scenario.taxRate / 100 : 0
+          const result = calculateScenarioFinancials({
+            scenarioType: scenario.scenarioType,
+            price: scenario.price,
+            downPayment: scenario.downPayment,
+            termMonths: scenario.termMonths,
+            apr: scenario.apr,
+            moneyFactor: scenario.moneyFactor,
+            residualValue: scenario.residualValue,
+            fees: { total: scenario.feesTotal },
+            taxes: { rate: taxes },
+            metadata: {},
+          })
+          acc[scenario.scenarioType] = { result, error: null }
+        } catch (error) {
+          acc[scenario.scenarioType] = {
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        }
+        return acc
+      },
+      {},
+    )
+  }, [scenarios])
+
+  const updateScenario = useCallback(
+    (type: ScenarioFormState["scenarioType"], field: keyof ScenarioFormState, value: number | undefined) => {
+      setScenarios((prev) =>
+        prev.map((scenario) =>
+          scenario.scenarioType === type
+            ? {
+                ...scenario,
+                [field]: value,
+              }
+            : scenario,
+        ),
+      )
+    },
+    [],
+  )
+
+  const vehiclePayload = useMemo(() => {
+    const payload: Record<string, string> = {}
+    if (vehicleYear) payload.year = vehicleYear
+    if (vehicleMake) payload.make = vehicleMake
+    if (vehicleModel) payload.model = vehicleModel
+    if (vehicleTrim) payload.trim = vehicleTrim
+    if (vehicleVin) payload.vin = vehicleVin
+    return payload
+  }, [vehicleYear, vehicleMake, vehicleModel, vehicleTrim, vehicleVin])
+
+  const customerProfile = useMemo(() => {
+    return {
+      history: currentDeal?.scenarios ?? [],
+    }
+  }, [currentDeal])
+
+  const loadDealHistory = useCallback(async () => {
+    if (!storeId) return
+    setIsLoadingHistory(true)
+    try {
+      const response = await fetch(`/api/deals?storeId=${storeId}`)
+      if (!response.ok) {
+        throw new Error("Failed to load deal history")
+      }
+      const data = (await response.json()) as DealSummary[]
+      setDealHistory(data)
+    } catch (error) {
+      toast({ title: "History error", description: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setIsLoadingHistory(false)
+    }
+  }, [storeId])
+
+  useEffect(() => {
+    if (storeId) {
+      void loadDealHistory()
+    }
+  }, [loadDealHistory, storeId])
+
+  const persistDeal = useCallback(async () => {
+    if (!storeId) {
+      toast({ title: "Store ID required", description: "Provide a store identifier before saving." })
+      return
+    }
+    if (!storeName) {
+      toast({ title: "Store name required", description: "Provide the store name to persist presets." })
+      return
+    }
+    if (!customerFirstName || !customerLastName) {
+      toast({ title: "Customer details required", description: "Customer first and last name are mandatory." })
+      return
+    }
+    setIsSaving(true)
+    try {
+      const response = await fetch("/api/deals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dealId: currentDeal?.deal.id,
+          storeId,
+          storeProfile: {
+            name: storeName,
+            contactEmail: storeEmail || undefined,
+            contactPhone: storePhone || undefined,
+            address: storeAddress || undefined,
+            settings: {
+              defaultPreset: storePresetName,
+              defaultScenario: "finance",
+            },
+          },
+          title: dealTitle,
+          basePrice,
+          vehicle: vehiclePayload,
+          notes: dealNotes || undefined,
+          customer: {
+            id: customerId || undefined,
+            firstName: customerFirstName,
+            lastName: customerLastName,
+            email: customerEmail || undefined,
+            phone: customerPhone || undefined,
+            profile: customerProfile,
+          },
+          scenarios: scenarios.map((scenario) => ({
+            scenarioType: scenario.scenarioType,
+            price: scenario.price,
+            downPayment: scenario.downPayment,
+            termMonths: scenario.termMonths,
+            apr: scenario.apr,
+            moneyFactor: scenario.moneyFactor,
+            residualValue: scenario.residualValue,
+            fees: { total: scenario.feesTotal },
+            taxes: { rate: Number.isFinite(scenario.taxRate) ? scenario.taxRate / 100 : 0 },
+            metadata: { preparedBy: storeName },
+          })),
+          storePreset: {
+            presetName: storePresetName,
+            payload: {
+              scenarios,
+              basePrice,
+            },
+            isDefault: storePresetDefault,
+          },
+          customerPreset: {
+            presetName: customerPresetName,
+            payload: {
+              preferredContact: customerEmail || customerPhone,
+              notes: dealNotes,
+            },
+          },
+        }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: "Unknown error" }))
+        throw new Error(error.error ?? "Failed to save deal")
+      }
+
+      const data = (await response.json()) as DealResponse
+      setCurrentDeal(data)
+      setCustomerId(data.customer?.id ?? "")
+      toast({ title: "Deal saved", description: "Deal scenarios and presets have been persisted." })
+      await loadDealHistory()
+    } catch (error) {
+      toast({ title: "Save failed", description: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setIsSaving(false)
+    }
+  }, [
+    basePrice,
+    currentDeal?.deal.id,
+    customerId,
+    customerEmail,
+    customerFirstName,
+    customerLastName,
+    customerPhone,
+    customerPresetName,
+    customerProfile,
+    dealNotes,
+    dealTitle,
+    loadDealHistory,
+    scenarios,
+    storeAddress,
+    storeEmail,
+    storeId,
+    storeName,
+    storePhone,
+    storePresetDefault,
+    storePresetName,
+    vehiclePayload,
+  ])
+
+  const loadScenarioFromHistory = useCallback(
+    (scenario: DealScenario) => {
+      setScenarios((prev) =>
+        prev.map((current) =>
+          current.scenarioType === scenario.scenarioType
+            ? {
+                ...current,
+                price: scenario.price,
+                downPayment: scenario.downPayment,
+                termMonths: scenario.termMonths ?? undefined,
+                apr: scenario.apr ?? undefined,
+                moneyFactor: scenario.moneyFactor ?? undefined,
+                residualValue: scenario.residualValue ?? undefined,
+                feesTotal: typeof scenario.fees?.total === "number" ? (scenario.fees.total as number) : current.feesTotal,
+                taxRate:
+                  typeof scenario.taxes?.rate === "number"
+                    ? Number(((scenario.taxes.rate as number) * 100).toFixed(4))
+                    : current.taxRate,
+              }
+            : current,
+        ),
+      )
+      toast({
+        title: "Scenario loaded",
+        description: `${scenario.scenarioType.toUpperCase()} v${scenario.version} applied to the workspace`,
+      })
+    },
+    [],
+  )
+
+  const generatePdf = useCallback(
+    async (scenarioId: string) => {
+      if (!currentDeal) return
+      try {
+        const response = await fetch(`/api/deals/${currentDeal.deal.id}/documents`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ scenarioId, documentType: "deal_summary", preparedBy: storeName }),
+        })
+        if (!response.ok) {
+          const error = await response.json().catch(() => ({ error: "Failed to generate PDF" }))
+          throw new Error(error.error ?? "Failed to generate PDF")
+        }
+        const data = await response.json()
+        if (data?.pdf) {
+          const link = document.createElement("a")
+          link.href = `data:application/pdf;base64,${data.pdf}`
+          link.download = data.document.fileName
+          document.body.appendChild(link)
+          link.click()
+          document.body.removeChild(link)
+          toast({ title: "PDF ready", description: "The document has been generated and downloaded." })
+          await loadDealHistory()
+          const detail = await fetch(`/api/deals/${currentDeal.deal.id}`)
+          if (detail.ok) {
+            const detailData = (await detail.json()) as DealResponse
+            setCurrentDeal(detailData)
+          }
+        }
+      } catch (error) {
+        toast({ title: "PDF error", description: error instanceof Error ? error.message : String(error) })
+      }
+    },
+    [currentDeal, loadDealHistory, storeName],
+  )
+
+  return (
+    <div className="container mx-auto space-y-6 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold">Deal Structuring Workspace</h1>
+          <p className="text-muted-foreground">
+            Configure cash, finance, and lease options, persist presets, and generate professional PDFs.
+          </p>
+        </div>
+        <div className="space-x-2">
+          <Button onClick={persistDeal} disabled={isSaving}>
+            {isSaving ? "Saving..." : "Save Deal"}
+          </Button>
+          <Button variant="outline" onClick={loadDealHistory} disabled={!storeId || isLoadingHistory}>
+            {isLoadingHistory ? "Loading..." : "Refresh History"}
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Store &amp; Customer Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="storeId">Store Identifier</Label>
+              <Input id="storeId" value={storeId} onChange={(event) => setStoreId(event.target.value.trim())} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="storeName">Store Name</Label>
+              <Input id="storeName" value={storeName} onChange={(event) => setStoreName(event.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="storeEmail">Store Email</Label>
+              <Input
+                id="storeEmail"
+                type="email"
+                value={storeEmail}
+                onChange={(event) => setStoreEmail(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="storePhone">Store Phone</Label>
+              <Input id="storePhone" value={storePhone} onChange={(event) => setStorePhone(event.target.value)} />
+            </div>
+            <div className="space-y-2 md:col-span-2">
+              <Label htmlFor="storeAddress">Store Address</Label>
+              <Input
+                id="storeAddress"
+                value={storeAddress}
+                onChange={(event) => setStoreAddress(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="customerId">Customer ID (optional)</Label>
+              <Input id="customerId" value={customerId} onChange={(event) => setCustomerId(event.target.value.trim())} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="customerFirstName">Customer First Name</Label>
+              <Input
+                id="customerFirstName"
+                value={customerFirstName}
+                onChange={(event) => setCustomerFirstName(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="customerLastName">Customer Last Name</Label>
+              <Input
+                id="customerLastName"
+                value={customerLastName}
+                onChange={(event) => setCustomerLastName(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="customerEmail">Customer Email</Label>
+              <Input
+                id="customerEmail"
+                type="email"
+                value={customerEmail}
+                onChange={(event) => setCustomerEmail(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="customerPhone">Customer Phone</Label>
+              <Input
+                id="customerPhone"
+                value={customerPhone}
+                onChange={(event) => setCustomerPhone(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="storePresetName">Store Preset Name</Label>
+              <Input
+                id="storePresetName"
+                value={storePresetName}
+                onChange={(event) => setStorePresetName(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="customerPresetName">Customer Preset Name</Label>
+              <Input
+                id="customerPresetName"
+                value={customerPresetName}
+                onChange={(event) => setCustomerPresetName(event.target.value)}
+              />
+            </div>
+            <div className="flex items-center space-x-2">
+              <input
+                id="storePresetDefault"
+                type="checkbox"
+                checked={storePresetDefault}
+                onChange={(event) => setStorePresetDefault(event.target.checked)}
+              />
+              <Label htmlFor="storePresetDefault">Use as default store preset</Label>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Vehicle &amp; Deal Overview</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="dealTitle">Deal Title</Label>
+              <Input id="dealTitle" value={dealTitle} onChange={(event) => setDealTitle(event.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="basePrice">Base Price</Label>
+              <Input
+                id="basePrice"
+                type="number"
+                value={basePrice}
+                onChange={(event) => setBasePrice(toNumber(event.target.value, basePrice))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vehicleVin">Vehicle VIN</Label>
+              <Input id="vehicleVin" value={vehicleVin} onChange={(event) => setVehicleVin(event.target.value)} />
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-4">
+            <div className="space-y-2">
+              <Label htmlFor="vehicleYear">Year</Label>
+              <Input id="vehicleYear" value={vehicleYear} onChange={(event) => setVehicleYear(event.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vehicleMake">Make</Label>
+              <Input id="vehicleMake" value={vehicleMake} onChange={(event) => setVehicleMake(event.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vehicleModel">Model</Label>
+              <Input id="vehicleModel" value={vehicleModel} onChange={(event) => setVehicleModel(event.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vehicleTrim">Trim</Label>
+              <Input id="vehicleTrim" value={vehicleTrim} onChange={(event) => setVehicleTrim(event.target.value)} />
+            </div>
+          </div>
+          <Textarea
+            placeholder="Internal notes, incentives, or delivery information"
+            value={dealNotes}
+            onChange={(event) => setDealNotes(event.target.value)}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Scenario Builder</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <Tabs defaultValue="cash" className="space-y-6">
+            <TabsList>
+              <TabsTrigger value="cash">Cash</TabsTrigger>
+              <TabsTrigger value="finance">Finance</TabsTrigger>
+              <TabsTrigger value="lease">Lease</TabsTrigger>
+            </TabsList>
+            {scenarios.map((scenario) => {
+              const calculation = scenarioCalculations[scenario.scenarioType]
+              return (
+                <TabsContent key={scenario.scenarioType} value={scenario.scenarioType} className="space-y-6">
+                  <div className="grid gap-4 md:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label htmlFor={`${scenario.scenarioType}-price`}>Vehicle Price</Label>
+                      <Input
+                        id={`${scenario.scenarioType}-price`}
+                        type="number"
+                        value={scenario.price}
+                        onChange={(event) => updateScenario(scenario.scenarioType, "price", toNumber(event.target.value))}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`${scenario.scenarioType}-down`}>Down Payment</Label>
+                      <Input
+                        id={`${scenario.scenarioType}-down`}
+                        type="number"
+                        value={scenario.downPayment}
+                        onChange={(event) =>
+                          updateScenario(scenario.scenarioType, "downPayment", toNumber(event.target.value))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`${scenario.scenarioType}-fees`}>Total Fees</Label>
+                      <Input
+                        id={`${scenario.scenarioType}-fees`}
+                        type="number"
+                        value={scenario.feesTotal}
+                        onChange={(event) => updateScenario(scenario.scenarioType, "feesTotal", toNumber(event.target.value))}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-3">
+                    {(scenario.scenarioType === "finance" || scenario.scenarioType === "lease") && (
+                      <div className="space-y-2">
+                        <Label htmlFor={`${scenario.scenarioType}-term`}>Term (months)</Label>
+                        <Input
+                          id={`${scenario.scenarioType}-term`}
+                          type="number"
+                          value={scenario.termMonths ?? ""}
+                          onChange={(event) =>
+                            updateScenario(
+                              scenario.scenarioType,
+                              "termMonths",
+                              event.target.value ? toNumber(event.target.value) : undefined,
+                            )
+                          }
+                        />
+                      </div>
+                    )}
+                    {scenario.scenarioType === "finance" && (
+                      <div className="space-y-2">
+                        <Label htmlFor="finance-apr">APR (%)</Label>
+                        <Input
+                          id="finance-apr"
+                          type="number"
+                          step="0.001"
+                          value={scenario.apr ?? ""}
+                          onChange={(event) =>
+                            updateScenario(
+                              scenario.scenarioType,
+                              "apr",
+                              event.target.value ? toNumber(event.target.value) : undefined,
+                            )
+                          }
+                        />
+                      </div>
+                    )}
+                    {scenario.scenarioType === "lease" && (
+                      <>
+                        <div className="space-y-2">
+                          <Label htmlFor="lease-moneyFactor">Money Factor</Label>
+                          <Input
+                            id="lease-moneyFactor"
+                            type="number"
+                            step="0.000001"
+                            value={scenario.moneyFactor ?? ""}
+                            onChange={(event) =>
+                              updateScenario(
+                                scenario.scenarioType,
+                                "moneyFactor",
+                                event.target.value ? toNumber(event.target.value) : undefined,
+                              )
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="lease-residual">Residual Value</Label>
+                          <Input
+                            id="lease-residual"
+                            type="number"
+                            value={scenario.residualValue ?? ""}
+                            onChange={(event) =>
+                              updateScenario(
+                                scenario.scenarioType,
+                                "residualValue",
+                                event.target.value ? toNumber(event.target.value) : undefined,
+                              )
+                            }
+                          />
+                        </div>
+                      </>
+                    )}
+                    <div className="space-y-2">
+                      <Label htmlFor={`${scenario.scenarioType}-tax`}>Tax Rate (%)</Label>
+                      <Input
+                        id={`${scenario.scenarioType}-tax`}
+                        type="number"
+                        step="0.01"
+                        value={scenario.taxRate}
+                        onChange={(event) => updateScenario(scenario.scenarioType, "taxRate", toNumber(event.target.value))}
+                      />
+                    </div>
+                  </div>
+
+                  {calculation?.error ? (
+                    <p className="text-sm text-destructive">{calculation.error}</p>
+                  ) : calculation?.result ? (
+                    <div className="grid gap-4 md:grid-cols-4">
+                      <div className="rounded-md border p-4">
+                        <p className="text-sm text-muted-foreground">Monthly Payment</p>
+                        <p className="text-xl font-semibold">
+                          {formatCurrency(calculation.result.monthlyPayment)}
+                        </p>
+                      </div>
+                      <div className="rounded-md border p-4">
+                        <p className="text-sm text-muted-foreground">Due at Signing</p>
+                        <p className="text-xl font-semibold">
+                          {formatCurrency(calculation.result.totalDueAtSigning)}
+                        </p>
+                      </div>
+                      <div className="rounded-md border p-4">
+                        <p className="text-sm text-muted-foreground">Capitalized Cost</p>
+                        <p className="text-xl font-semibold">
+                          {formatCurrency(calculation.result.capitalizedCost)}
+                        </p>
+                      </div>
+                      <div className="rounded-md border p-4">
+                        <p className="text-sm text-muted-foreground">Taxes</p>
+                        <p className="text-xl font-semibold">{formatCurrency(calculation.result.taxAmount)}</p>
+                      </div>
+                    </div>
+                  ) : null}
+                </TabsContent>
+              )
+            })}
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      {currentDeal && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Current Deal Summary</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <p className="font-medium">Deal ID: {currentDeal.deal.id}</p>
+              <p className="text-sm text-muted-foreground">Updated: {new Date(currentDeal.deal.updatedAt).toLocaleString()}</p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              {currentDeal.scenarios.map((scenario) => (
+                <div key={scenario.id} className="rounded-lg border p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-semibold">{scenario.scenarioType.toUpperCase()} v{scenario.version}</p>
+                      <p className="text-sm text-muted-foreground">
+                        Payment: {scenario.payment ? formatCurrency(scenario.payment) : "N/A"}
+                      </p>
+                    </div>
+                    <Button size="sm" onClick={() => generatePdf(scenario.id)}>
+                      Generate PDF
+                    </Button>
+                  </div>
+                  <Button variant="outline" className="mt-3 w-full" onClick={() => loadScenarioFromHistory(scenario)}>
+                    Load Scenario
+                  </Button>
+                </div>
+              ))}
+            </div>
+            {currentDeal.documents.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold">Generated Documents</h3>
+                <div className="space-y-2">
+                  {currentDeal.documents.map((doc) => (
+                    <div key={doc.id} className="flex items-center justify-between rounded border p-3">
+                      <div>
+                        <p className="font-medium">{doc.fileName}</p>
+                        <p className="text-sm text-muted-foreground">
+                          Created {new Date(doc.createdAt).toLocaleString()}
+                        </p>
+                      </div>
+                      <Button asChild variant="outline" size="sm">
+                        <a href={`/api/deals/${currentDeal.deal.id}/documents/${doc.id}`} target="_blank" rel="noreferrer">
+                          Download
+                        </a>
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Deal History</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {dealHistory.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No deals saved for this store yet.</p>
+          ) : (
+            dealHistory.map((deal) => (
+              <div key={deal.id} className="space-y-3 rounded-lg border p-4">
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <p className="font-semibold">{deal.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Customer: {deal.customerName ?? "Unassigned"} · Last Updated: {" "}
+                      {new Date(deal.updatedAt).toLocaleString()}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {deal.documents.map((doc) => (
+                      <Button key={doc.id} asChild size="sm" variant="outline">
+                        <a href={`/api/deals/${deal.id}/documents/${doc.id}`} target="_blank" rel="noreferrer">
+                          {doc.documentType.toUpperCase()}
+                        </a>
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {deal.scenarios.map((scenario) => (
+                    <Button
+                      key={scenario.id}
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => loadScenarioFromHistory(scenario)}
+                    >
+                      {scenario.scenarioType.toUpperCase()} v{scenario.version}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from 'next'
-import './globals.css'
+import type { Metadata } from "next"
+import "./globals.css"
+import { Toaster } from "@/components/ui/toaster"
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -14,7 +15,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Toaster />
+      </body>
     </html>
   )
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -117,3 +117,87 @@ export interface Configuration {
   value: string
   updated_at: Date
 }
+
+export interface Store {
+  id: string
+  name: string
+  contact_email: string | null
+  contact_phone: string | null
+  address: string | null
+  settings: Record<string, unknown>
+  created_at: Date
+  updated_at: Date
+}
+
+export interface StoreDealPreset {
+  id: string
+  store_id: string
+  preset_name: string
+  payload: Record<string, unknown>
+  is_default: boolean
+  created_at: Date
+  updated_at: Date
+}
+
+export interface Customer {
+  id: string
+  store_id: string
+  first_name: string
+  last_name: string
+  email: string | null
+  phone: string | null
+  profile: Record<string, unknown>
+  created_at: Date
+  updated_at: Date
+}
+
+export interface CustomerDealPreset {
+  id: string
+  customer_id: string
+  preset_name: string
+  payload: Record<string, unknown>
+  created_at: Date
+  updated_at: Date
+}
+
+export interface Deal {
+  id: string
+  store_id: string
+  customer_id: string | null
+  title: string
+  vehicle: Record<string, unknown>
+  status: string
+  base_price: string
+  notes: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export interface DealScenario {
+  id: string
+  deal_id: string
+  scenario_type: string
+  version: number
+  price: string
+  down_payment: string | null
+  term_months: number | null
+  apr: string | null
+  money_factor: string | null
+  residual_value: string | null
+  payment: string | null
+  fees: Record<string, unknown>
+  taxes: Record<string, unknown>
+  metadata: Record<string, unknown>
+  created_at: Date
+}
+
+export interface DealDocument {
+  id: string
+  deal_id: string
+  scenario_id: string | null
+  document_type: string
+  file_name: string
+  pdf_data: Buffer
+  metadata: Record<string, unknown>
+  created_at: Date
+}

--- a/lib/deal-calculations.ts
+++ b/lib/deal-calculations.ts
@@ -1,0 +1,181 @@
+import { z } from "zod"
+
+export const jsonValueSchema = z.any().superRefine((value, ctx) => {
+  try {
+    JSON.stringify(value)
+  } catch {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Value must be JSON serializable" })
+  }
+})
+
+export type JsonValue = z.infer<typeof jsonValueSchema>
+
+export const scenarioTypeEnum = z.enum(["cash", "finance", "lease"])
+
+export const scenarioSchema = z.object({
+  scenarioType: scenarioTypeEnum,
+  price: z.number().nonnegative(),
+  downPayment: z.number().nonnegative().default(0),
+  termMonths: z.number().int().positive().optional(),
+  apr: z.number().nonnegative().optional(),
+  moneyFactor: z.number().nonnegative().optional(),
+  residualValue: z.number().nonnegative().optional(),
+  fees: jsonValueSchema.optional().default({}),
+  taxes: jsonValueSchema.optional().default({}),
+  metadata: jsonValueSchema.optional().default({}),
+})
+
+export type ScenarioInput = z.infer<typeof scenarioSchema>
+
+export interface ScenarioFinancials {
+  monthlyPayment: number
+  totalDueAtSigning: number
+  feesTotal: number
+  taxAmount: number
+  capitalizedCost: number
+  residualValue?: number
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function sumArray(values: unknown[]): number {
+  return values.reduce((acc, value) => {
+    const num = toNumber(value)
+    return acc + (num ?? 0)
+  }, 0)
+}
+
+export function calculateTotalFees(fees: JsonValue | undefined): number {
+  if (!fees) return 0
+  if (typeof fees === "number") {
+    return fees
+  }
+  if (Array.isArray(fees)) {
+    return sumArray(
+      fees.map((item) => {
+        if (typeof item === "number") return item
+        if (item && typeof item === "object" && "amount" in item) {
+          return (item as Record<string, unknown>).amount
+        }
+        return 0
+      }),
+    )
+  }
+  if (typeof fees === "object") {
+    if ("total" in fees) {
+      const total = toNumber((fees as Record<string, unknown>).total)
+      if (total !== null) {
+        return total
+      }
+    }
+    if ("items" in fees && Array.isArray((fees as Record<string, unknown>).items)) {
+      return sumArray(
+        ((fees as Record<string, unknown>).items as unknown[]).map((item) => {
+          if (item && typeof item === "object" && "amount" in item) {
+            return (item as Record<string, unknown>).amount
+          }
+          return 0
+        }),
+      )
+    }
+    return sumArray(Object.values(fees))
+  }
+  return 0
+}
+
+export function calculateTaxAmount(taxes: JsonValue | undefined, baseAmount: number): number {
+  if (!taxes) return 0
+  if (typeof taxes === "number") {
+    return taxes
+  }
+  if (typeof taxes === "object") {
+    const record = taxes as Record<string, unknown>
+    if ("amount" in record) {
+      const amount = toNumber(record.amount)
+      if (amount !== null) return amount
+    }
+    if ("monthly" in record) {
+      const monthly = toNumber(record.monthly)
+      if (monthly !== null) return monthly
+    }
+    if ("rate" in record) {
+      const rate = toNumber(record.rate)
+      if (rate !== null) return baseAmount * rate
+    }
+  }
+  return 0
+}
+
+export function calculateScenarioFinancials(input: ScenarioInput): ScenarioFinancials {
+  const feesTotal = calculateTotalFees(input.fees)
+  const price = input.price
+  const downPayment = input.downPayment ?? 0
+  const capitalizedCost = price - downPayment + feesTotal
+
+  if (input.scenarioType === "cash") {
+    const taxes = calculateTaxAmount(input.taxes, capitalizedCost)
+    return {
+      monthlyPayment: capitalizedCost + taxes,
+      totalDueAtSigning: capitalizedCost + taxes,
+      feesTotal,
+      taxAmount: taxes,
+      capitalizedCost,
+    }
+  }
+
+  if (input.scenarioType === "finance") {
+    const term = input.termMonths ?? 0
+    if (!term) {
+      throw new Error("Finance scenarios require termMonths to calculate payments.")
+    }
+    const apr = input.apr ?? 0
+    const monthlyRate = apr > 0 ? apr / 100 / 12 : 0
+    const principal = capitalizedCost
+    let basePayment = 0
+    if (monthlyRate === 0) {
+      basePayment = principal / term
+    } else {
+      basePayment = (principal * monthlyRate) / (1 - Math.pow(1 + monthlyRate, -term))
+    }
+    const taxes = calculateTaxAmount(input.taxes, basePayment)
+    return {
+      monthlyPayment: basePayment + taxes,
+      totalDueAtSigning: downPayment + feesTotal,
+      feesTotal,
+      taxAmount: taxes,
+      capitalizedCost,
+    }
+  }
+
+  // lease
+  const term = input.termMonths ?? 0
+  if (!term) {
+    throw new Error("Lease scenarios require termMonths to calculate payments.")
+  }
+  const residualValue = input.residualValue ?? 0
+  const moneyFactor = input.moneyFactor ?? 0
+  const depreciation = (capitalizedCost - residualValue) / term
+  const rentCharge = (capitalizedCost + residualValue) * moneyFactor
+  const basePayment = depreciation + rentCharge
+  const taxes = calculateTaxAmount(input.taxes, basePayment)
+  return {
+    monthlyPayment: basePayment + taxes,
+    totalDueAtSigning: downPayment + feesTotal,
+    feesTotal,
+    taxAmount: taxes,
+    capitalizedCost,
+    residualValue,
+  }
+}
+
+export function formatCurrency(amount: number, currency = "USD"): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+  }).format(amount)
+}

--- a/lib/deal-service.ts
+++ b/lib/deal-service.ts
@@ -1,0 +1,825 @@
+import { query, transaction } from "./db"
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib"
+import type { PDFFont, PDFPage } from "pdf-lib"
+import { z } from "zod"
+import {
+  calculateScenarioFinancials,
+  formatCurrency,
+  jsonValueSchema,
+  scenarioSchema,
+  type JsonValue,
+  type ScenarioInput,
+} from "./deal-calculations"
+
+interface DealListFilter {
+  storeId: string
+  customerId?: string
+}
+
+const storeProfileSchema = z
+  .object({
+    name: z.string().min(1),
+    contactEmail: z.string().email().optional(),
+    contactPhone: z.string().optional(),
+    address: z.string().optional(),
+    settings: jsonValueSchema.optional(),
+  })
+  .partial({ name: true })
+
+const customerSchema = z.object({
+  id: z.string().uuid().optional(),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  email: z.string().email().optional(),
+  phone: z.string().optional(),
+  profile: jsonValueSchema.optional(),
+})
+
+const storePresetSchema = z.object({
+  presetName: z.string().min(1),
+  payload: jsonValueSchema,
+  isDefault: z.boolean().optional(),
+})
+
+const customerPresetSchema = z.object({
+  presetName: z.string().min(1),
+  payload: jsonValueSchema,
+})
+
+const dealUpsertSchema = z.object({
+  dealId: z.string().uuid().optional(),
+  storeId: z.string().uuid(),
+  storeProfile: storeProfileSchema.optional(),
+  title: z.string().min(1),
+  basePrice: z.number().nonnegative(),
+  vehicle: jsonValueSchema.optional(),
+  notes: z.string().optional(),
+  status: z.string().optional(),
+  customer: customerSchema,
+  scenarios: z.array(
+    scenarioSchema.extend({
+      id: z.string().uuid().optional(),
+      version: z.number().int().positive().optional(),
+    }),
+  ),
+  storePreset: storePresetSchema.optional(),
+  customerPreset: customerPresetSchema.optional(),
+})
+
+const documentRequestSchema = z.object({
+  scenarioId: z.string().uuid(),
+  documentType: z.string().default("deal_summary"),
+  preparedBy: z.string().optional(),
+})
+
+function ensureJson(value: JsonValue | undefined): Record<string, unknown> {
+  if (value === undefined || value === null) {
+    return {}
+  }
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return { value }
+}
+
+function parseNumeric(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function sanitizeJson(value: JsonValue | undefined) {
+  if (value === undefined) {
+    return {}
+  }
+  try {
+    return JSON.parse(JSON.stringify(value))
+  } catch {
+    throw new Error("Unable to serialize JSON payload")
+  }
+}
+
+function buildVehicleDescription(vehicle: Record<string, unknown> | undefined): string {
+  if (!vehicle) return ""
+  const year = vehicle["year"]
+  const make = vehicle["make"]
+  const model = vehicle["model"]
+  const trim = vehicle["trim"]
+  const parts = [year, make, model, trim].filter((part) => typeof part === "string" || typeof part === "number")
+  return parts.join(" ")
+}
+
+async function ensureStore(
+  client: { query: typeof query },
+  storeId: string,
+  storeProfile?: z.infer<typeof storeProfileSchema>,
+) {
+  const existing = await client.query(`SELECT * FROM stores WHERE id = $1`, [storeId])
+  if (existing.rows.length === 0) {
+    if (!storeProfile?.name) {
+      throw new Error("Store does not exist and no store profile was provided to create it.")
+    }
+    await client.query(
+      `INSERT INTO stores (id, name, contact_email, contact_phone, address, settings) VALUES ($1, $2, $3, $4, $5, $6)`,
+      [
+        storeId,
+        storeProfile.name,
+        storeProfile.contactEmail ?? null,
+        storeProfile.contactPhone ?? null,
+        storeProfile.address ?? null,
+        sanitizeJson(storeProfile.settings ?? {}),
+      ],
+    )
+    return
+  }
+
+  if (storeProfile) {
+    await client.query(
+      `UPDATE stores SET
+        name = COALESCE($2, name),
+        contact_email = COALESCE($3, contact_email),
+        contact_phone = COALESCE($4, contact_phone),
+        address = COALESCE($5, address),
+        settings = COALESCE($6::jsonb, settings),
+        updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [
+        storeId,
+        storeProfile.name ?? null,
+        storeProfile.contactEmail ?? null,
+        storeProfile.contactPhone ?? null,
+        storeProfile.address ?? null,
+        storeProfile.settings ? sanitizeJson(storeProfile.settings) : null,
+      ],
+    )
+  }
+}
+
+async function upsertStorePreset(
+  client: { query: typeof query },
+  storeId: string,
+  preset?: z.infer<typeof storePresetSchema>,
+) {
+  if (!preset) return null
+  const result = await client.query(
+    `INSERT INTO store_deal_presets (store_id, preset_name, payload, is_default)
+     VALUES ($1, $2, $3, COALESCE($4, FALSE))
+     ON CONFLICT (store_id, preset_name)
+     DO UPDATE SET payload = EXCLUDED.payload, is_default = EXCLUDED.is_default, updated_at = CURRENT_TIMESTAMP
+     RETURNING *`,
+    [storeId, preset.presetName, sanitizeJson(preset.payload), preset.isDefault ?? false],
+  )
+  return result.rows[0] ?? null
+}
+
+async function upsertCustomer(
+  client: { query: typeof query },
+  storeId: string,
+  customer: z.infer<typeof customerSchema>,
+) {
+  const profile = sanitizeJson(customer.profile ?? {})
+  if (customer.id) {
+    const result = await client.query(
+      `UPDATE customers SET
+         first_name = $2,
+         last_name = $3,
+         email = $4,
+         phone = $5,
+         profile = $6,
+         updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1
+       RETURNING *`,
+      [customer.id, customer.firstName, customer.lastName, customer.email ?? null, customer.phone ?? null, profile],
+    )
+    if (result.rows.length === 0) {
+      throw new Error("Customer not found for update")
+    }
+    return result.rows[0]
+  }
+
+  const result = await client.query(
+    `INSERT INTO customers (store_id, first_name, last_name, email, phone, profile)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [storeId, customer.firstName, customer.lastName, customer.email ?? null, customer.phone ?? null, profile],
+  )
+  return result.rows[0]
+}
+
+async function upsertCustomerPreset(
+  client: { query: typeof query },
+  customerId: string,
+  preset?: z.infer<typeof customerPresetSchema>,
+) {
+  if (!preset) return null
+  const result = await client.query(
+    `INSERT INTO customer_deal_presets (customer_id, preset_name, payload)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (customer_id, preset_name)
+     DO UPDATE SET payload = EXCLUDED.payload, updated_at = CURRENT_TIMESTAMP
+     RETURNING *`,
+    [customerId, preset.presetName, sanitizeJson(preset.payload)],
+  )
+  return result.rows[0] ?? null
+}
+
+async function insertDeal(
+  client: { query: typeof query },
+  payload: z.infer<typeof dealUpsertSchema>,
+  customerId: string | null,
+) {
+  const vehicle = sanitizeJson(payload.vehicle ?? {})
+  if (payload.dealId) {
+    const result = await client.query(
+      `UPDATE deals SET
+         customer_id = $2,
+         title = $3,
+         vehicle = $4,
+         status = COALESCE($5, status),
+         base_price = $6,
+         notes = $7,
+         updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1
+       RETURNING *`,
+      [payload.dealId, customerId, payload.title, vehicle, payload.status ?? null, payload.basePrice, payload.notes ?? null],
+    )
+    if (result.rows.length === 0) {
+      throw new Error("Deal not found for update")
+    }
+    return result.rows[0]
+  }
+
+  const result = await client.query(
+    `INSERT INTO deals (store_id, customer_id, title, vehicle, status, base_price, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING *`,
+    [
+      payload.storeId,
+      customerId,
+      payload.title,
+      vehicle,
+      payload.status ?? "active",
+      payload.basePrice,
+      payload.notes ?? null,
+    ],
+  )
+  return result.rows[0]
+}
+
+async function insertScenario(
+  client: { query: typeof query },
+  dealId: string,
+  scenario: ScenarioInput & { id?: string; version?: number },
+) {
+  const existingVersion = await client.query(
+    `SELECT COALESCE(MAX(version), 0) + 1 AS next_version FROM deal_scenarios WHERE deal_id = $1 AND scenario_type = $2`,
+    [dealId, scenario.scenarioType],
+  )
+  const version = scenario.version ?? Number(existingVersion.rows[0]?.next_version ?? 1)
+  const financials = calculateScenarioFinancials(scenario)
+  const result = await client.query(
+    `INSERT INTO deal_scenarios (
+        deal_id,
+        scenario_type,
+        version,
+        price,
+        down_payment,
+        term_months,
+        apr,
+        money_factor,
+        residual_value,
+        payment,
+        fees,
+        taxes,
+        metadata
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+      RETURNING *`,
+    [
+      dealId,
+      scenario.scenarioType,
+      version,
+      scenario.price,
+      scenario.downPayment ?? 0,
+      scenario.termMonths ?? null,
+      scenario.apr ?? null,
+      scenario.moneyFactor ?? null,
+      scenario.residualValue ?? null,
+      financials.monthlyPayment,
+      sanitizeJson(scenario.fees ?? {}),
+      sanitizeJson(scenario.taxes ?? {}),
+      sanitizeJson(scenario.metadata ?? {}),
+    ],
+  )
+  return {
+    row: result.rows[0] as Record<string, unknown>,
+    calculations: financials,
+  }
+}
+
+function normalizeDealRow(row: Record<string, unknown>) {
+  return {
+    id: row.id as string,
+    storeId: row.store_id as string,
+    customerId: (row.customer_id as string) ?? null,
+    title: row.title as string,
+    vehicle:
+      row.vehicle && typeof row.vehicle === "object"
+        ? (row.vehicle as Record<string, unknown>)
+        : {},
+    status: row.status as string,
+    basePrice: parseNumeric(row.base_price) ?? 0,
+    notes: (row.notes as string) ?? null,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  }
+}
+
+function normalizeScenarioRow(row: Record<string, unknown>) {
+  return {
+    id: row.id as string,
+    dealId: row.deal_id as string,
+    scenarioType: row.scenario_type as ScenarioInput["scenarioType"],
+    version: Number(row.version ?? 0),
+    price: parseNumeric(row.price) ?? 0,
+    downPayment: parseNumeric(row.down_payment) ?? 0,
+    termMonths: (row.term_months as number) ?? null,
+    apr: row.apr !== null ? parseNumeric(row.apr) : null,
+    moneyFactor: row.money_factor !== null ? parseNumeric(row.money_factor) : null,
+    residualValue: row.residual_value !== null ? parseNumeric(row.residual_value) : null,
+    payment: row.payment !== null ? parseNumeric(row.payment) : null,
+    fees:
+      row.fees && typeof row.fees === "object"
+        ? (row.fees as Record<string, unknown>)
+        : {},
+    taxes:
+      row.taxes && typeof row.taxes === "object"
+        ? (row.taxes as Record<string, unknown>)
+        : {},
+    metadata:
+      row.metadata && typeof row.metadata === "object"
+        ? (row.metadata as Record<string, unknown>)
+        : {},
+    createdAt: row.created_at as string,
+  }
+}
+
+function normalizeDocumentRow(row: Record<string, unknown>) {
+  return {
+    id: row.id as string,
+    dealId: row.deal_id as string,
+    scenarioId: (row.scenario_id as string) ?? null,
+    documentType: row.document_type as string,
+    fileName: row.file_name as string,
+    createdAt: row.created_at as string,
+    metadata:
+      row.metadata && typeof row.metadata === "object"
+        ? (row.metadata as Record<string, unknown>)
+        : {},
+  }
+}
+
+export async function saveDeal(payload: unknown) {
+  const input = dealUpsertSchema.parse(payload)
+  const transactionResult = await transaction(async (client) => {
+    await ensureStore(client, input.storeId, input.storeProfile)
+    const storePreset = await upsertStorePreset(client, input.storeId, input.storePreset)
+    const customerRow = await upsertCustomer(client, input.storeId, input.customer)
+    const customerPreset = await upsertCustomerPreset(client, customerRow.id, input.customerPreset)
+    const dealRow = await insertDeal(client, input, customerRow.id)
+    const scenarios = [] as Array<ReturnType<typeof normalizeScenarioRow> & { calculations: ReturnType<typeof calculateScenarioFinancials> }>
+
+    for (const scenarioInput of input.scenarios) {
+      const parsed = scenarioSchema.parse({
+        scenarioType: scenarioInput.scenarioType,
+        price: scenarioInput.price,
+        downPayment: scenarioInput.downPayment ?? 0,
+        termMonths: scenarioInput.termMonths,
+        apr: scenarioInput.apr,
+        moneyFactor: scenarioInput.moneyFactor,
+        residualValue: scenarioInput.residualValue,
+        fees: scenarioInput.fees ?? {},
+        taxes: scenarioInput.taxes ?? {},
+        metadata: scenarioInput.metadata ?? {},
+      })
+      const created = await insertScenario(client, dealRow.id, { ...parsed, version: scenarioInput.version })
+      const normalized = normalizeScenarioRow(created.row)
+      scenarios.push({ ...normalized, calculations: created.calculations })
+    }
+
+    return {
+      deal: normalizeDealRow(dealRow),
+      customer: {
+        id: customerRow.id,
+        firstName: customerRow.first_name,
+        lastName: customerRow.last_name,
+        email: customerRow.email,
+        phone: customerRow.phone,
+        profile: customerRow.profile ?? {},
+      },
+      storePreset: storePreset ? ensureJson(storePreset.payload) : null,
+      customerPreset: customerPreset ? ensureJson(customerPreset.payload) : null,
+      scenarios,
+    }
+  })
+
+  const dealDetails = await getDeal(transactionResult.deal.id)
+  return {
+    ...dealDetails,
+    calculations: Object.fromEntries(
+      transactionResult.scenarios.map((scenario) => [scenario.id, scenario.calculations]),
+    ),
+  }
+}
+
+export async function listDeals(filter: DealListFilter) {
+  const params = [filter.storeId]
+  let where = "WHERE d.store_id = $1"
+  if (filter.customerId) {
+    params.push(filter.customerId)
+    where += ` AND d.customer_id = $${params.length}`
+  }
+  const deals = await query(
+    `SELECT d.*, s.name AS store_name, c.first_name, c.last_name
+     FROM deals d
+     JOIN stores s ON s.id = d.store_id
+     LEFT JOIN customers c ON c.id = d.customer_id
+     ${where}
+     ORDER BY d.updated_at DESC`,
+    params,
+  )
+
+  const dealRows = deals.rows as Array<Record<string, unknown>>
+  const dealIds = dealRows.map((row) => row.id as string)
+  const scenarios = dealIds.length
+    ? await query(
+        `SELECT * FROM deal_scenarios WHERE deal_id = ANY($1::uuid[]) ORDER BY created_at DESC`,
+        [dealIds],
+      )
+    : { rows: [] }
+
+  const documents = dealIds.length
+    ? await query(
+        `SELECT id, deal_id, scenario_id, document_type, file_name, created_at, metadata
+         FROM deal_documents
+         WHERE deal_id = ANY($1::uuid[])
+         ORDER BY created_at DESC`,
+        [dealIds],
+      )
+    : { rows: [] }
+
+  const scenarioMap = new Map<string, ReturnType<typeof normalizeScenarioRow>[]>()
+  const scenarioRows = scenarios.rows as Array<Record<string, unknown>>
+  for (const row of scenarioRows) {
+    const dealId = row.deal_id as string
+    const list = scenarioMap.get(dealId) ?? []
+    list.push(normalizeScenarioRow(row))
+    scenarioMap.set(dealId, list)
+  }
+
+  const documentMap = new Map<string, ReturnType<typeof normalizeDocumentRow>[]>()
+  const documentRows = documents.rows as Array<Record<string, unknown>>
+  for (const row of documentRows) {
+    const dealId = row.deal_id as string
+    const list = documentMap.get(dealId) ?? []
+    list.push(normalizeDocumentRow(row))
+    documentMap.set(dealId, list)
+  }
+
+  return dealRows.map((row) => {
+    const id = row.id as string
+    const firstName = (row.first_name as string) ?? ""
+    const lastName = (row.last_name as string) ?? ""
+    const name = firstName ? `${firstName} ${lastName}`.trim() : null
+    return {
+      ...normalizeDealRow(row),
+      storeName: (row.store_name as string) ?? "",
+      customerName: name,
+      scenarios: scenarioMap.get(id) ?? [],
+      documents: documentMap.get(id) ?? [],
+    }
+  })
+}
+
+export async function getDeal(dealId: string) {
+  const dealResult = await query(
+    `SELECT d.*, s.name AS store_name, s.contact_email, s.contact_phone, s.address, s.settings,
+            c.first_name, c.last_name, c.email, c.phone, c.profile
+     FROM deals d
+     JOIN stores s ON s.id = d.store_id
+     LEFT JOIN customers c ON c.id = d.customer_id
+     WHERE d.id = $1`,
+    [dealId],
+  )
+  if (dealResult.rows.length === 0) {
+    throw new Error("Deal not found")
+  }
+  const dealRow = dealResult.rows[0] as Record<string, unknown>
+  const scenarioResult = await query(
+    `SELECT * FROM deal_scenarios WHERE deal_id = $1 ORDER BY created_at DESC`,
+    [dealId],
+  )
+  const documentResult = await query(
+    `SELECT id, deal_id, scenario_id, document_type, file_name, created_at, metadata
+     FROM deal_documents WHERE deal_id = $1 ORDER BY created_at DESC`,
+    [dealId],
+  )
+
+  return {
+    deal: normalizeDealRow(dealRow),
+    store: {
+      id: dealRow.store_id as string,
+      name: (dealRow.store_name as string) ?? "",
+      contactEmail: (dealRow.contact_email as string) ?? null,
+      contactPhone: (dealRow.contact_phone as string) ?? null,
+      address: (dealRow.address as string) ?? null,
+      settings:
+        dealRow.settings && typeof dealRow.settings === "object"
+          ? (dealRow.settings as Record<string, unknown>)
+          : {},
+    },
+    customer: dealRow.first_name
+      ? {
+          id: (dealRow.customer_id as string) ?? null,
+          firstName: (dealRow.first_name as string) ?? "",
+          lastName: (dealRow.last_name as string) ?? "",
+          email: (dealRow.email as string) ?? null,
+          phone: (dealRow.phone as string) ?? null,
+          profile:
+            dealRow.profile && typeof dealRow.profile === "object"
+              ? (dealRow.profile as Record<string, unknown>)
+              : {},
+        }
+      : null,
+    scenarios: (scenarioResult.rows as Array<Record<string, unknown>>).map((row) =>
+      normalizeScenarioRow(row),
+    ),
+    documents: (documentResult.rows as Array<Record<string, unknown>>).map((row) =>
+      normalizeDocumentRow(row),
+    ),
+  }
+}
+
+async function fetchScenarioForPdf(dealId: string, scenarioId: string) {
+  const result = await query(
+    `SELECT d.id as deal_id, d.title, d.base_price, d.vehicle, d.notes,
+            s.id as store_id, s.name as store_name, s.contact_email, s.contact_phone, s.address, s.settings,
+            c.id as customer_id, c.first_name, c.last_name, c.email as customer_email, c.phone as customer_phone, c.profile,
+            sc.id as scenario_id, sc.scenario_type, sc.version, sc.price, sc.down_payment, sc.term_months, sc.apr,
+            sc.money_factor, sc.residual_value, sc.payment, sc.fees, sc.taxes, sc.metadata, sc.created_at
+     FROM deals d
+     JOIN stores s ON s.id = d.store_id
+     LEFT JOIN customers c ON c.id = d.customer_id
+     JOIN deal_scenarios sc ON sc.id = $2 AND sc.deal_id = d.id
+     WHERE d.id = $1`,
+    [dealId, scenarioId],
+  )
+  if (result.rows.length === 0) {
+    throw new Error("Scenario not found for deal")
+  }
+  return result.rows[0] as Record<string, unknown>
+}
+
+function drawSectionHeader(page: PDFPage, font: PDFFont, text: string, x: number, y: number) {
+  page.drawText(text, {
+    x,
+    y,
+    size: 14,
+    font,
+    color: rgb(0.2, 0.2, 0.2),
+  })
+}
+
+function drawLabelValue(page: PDFPage, font: PDFFont, label: string, value: string, x: number, y: number) {
+  page.drawText(label, {
+    x,
+    y,
+    size: 10,
+    font,
+    color: rgb(0.35, 0.35, 0.35),
+  })
+  page.drawText(value, {
+    x,
+    y: y - 14,
+    size: 12,
+    font,
+    color: rgb(0, 0, 0),
+  })
+}
+
+export async function generateDealDocument(dealId: string, payload: unknown) {
+  const { scenarioId, documentType, preparedBy } = documentRequestSchema.parse(payload)
+  const row = await fetchScenarioForPdf(dealId, scenarioId)
+  const scenario = normalizeScenarioRow(row)
+  const deal = normalizeDealRow(row)
+  const doc = await PDFDocument.create()
+  const page = doc.addPage([595.28, 841.89])
+  const helvetica = await doc.embedFont(StandardFonts.Helvetica)
+  const helveticaBold = await doc.embedFont(StandardFonts.HelveticaBold)
+
+  const margin = 40
+  let cursor = page.getHeight() - margin
+
+  page.drawText("Professional Deal Summary", {
+    x: margin,
+    y: cursor,
+    size: 24,
+    font: helveticaBold,
+    color: rgb(0.1, 0.1, 0.1),
+  })
+  cursor -= 32
+
+  const storeName = (row.store_name as string) ?? ""
+  const prepared = preparedBy ? `Prepared by ${preparedBy}` : ""
+  drawLabelValue(page, helvetica, "Store", storeName, margin, cursor)
+  drawLabelValue(page, helvetica, "Deal", deal.title, margin + 280, cursor)
+  cursor -= 40
+
+  const vehicleDescription = buildVehicleDescription(
+    row.vehicle && typeof row.vehicle === "object"
+      ? (row.vehicle as Record<string, unknown>)
+      : undefined,
+  )
+  drawSectionHeader(page, helveticaBold, "Vehicle", margin, cursor)
+  cursor -= 24
+  drawLabelValue(page, helvetica, "Description", vehicleDescription || "N/A", margin, cursor)
+  drawLabelValue(
+    page,
+    helvetica,
+    "Base Price",
+    formatCurrency(parseNumeric(row.base_price) ?? 0),
+    margin + 280,
+    cursor,
+  )
+  cursor -= 40
+
+  drawSectionHeader(page, helveticaBold, "Scenario", margin, cursor)
+  cursor -= 24
+  drawLabelValue(page, helvetica, "Type", scenario.scenarioType.toUpperCase(), margin, cursor)
+  drawLabelValue(page, helvetica, "Version", `v${scenario.version}`, margin + 140, cursor)
+  drawLabelValue(
+    page,
+    helvetica,
+    "Monthly Payment",
+    scenario.payment !== null ? formatCurrency(scenario.payment) : "N/A",
+    margin + 280,
+    cursor,
+  )
+  cursor -= 40
+
+  const financials = calculateScenarioFinancials({
+    scenarioType: scenario.scenarioType as ScenarioInput["scenarioType"],
+    price: scenario.price,
+    downPayment: scenario.downPayment,
+    termMonths: scenario.termMonths ?? undefined,
+    apr: scenario.apr ?? undefined,
+    moneyFactor: scenario.moneyFactor ?? undefined,
+    residualValue: scenario.residualValue ?? undefined,
+    fees: scenario.fees,
+    taxes: scenario.taxes,
+    metadata: scenario.metadata,
+  })
+
+  drawLabelValue(
+    page,
+    helvetica,
+    "Capitalized Cost",
+    formatCurrency(financials.capitalizedCost),
+    margin,
+    cursor,
+  )
+  drawLabelValue(
+    page,
+    helvetica,
+    "Fees",
+    formatCurrency(financials.feesTotal),
+    margin + 200,
+    cursor,
+  )
+  drawLabelValue(
+    page,
+    helvetica,
+    "Taxes",
+    formatCurrency(financials.taxAmount),
+    margin + 350,
+    cursor,
+  )
+  cursor -= 40
+
+  if (scenario.scenarioType === "lease" && financials.residualValue !== undefined) {
+    drawLabelValue(
+      page,
+      helvetica,
+      "Residual Value",
+      formatCurrency(financials.residualValue),
+      margin,
+      cursor,
+    )
+    drawLabelValue(
+      page,
+      helvetica,
+      "Money Factor",
+      scenario.moneyFactor !== null ? `${scenario.moneyFactor?.toFixed(6)}` : "N/A",
+      margin + 200,
+      cursor,
+    )
+    cursor -= 40
+  }
+
+  if (scenario.scenarioType === "finance") {
+    drawLabelValue(
+      page,
+      helvetica,
+      "APR",
+      scenario.apr !== null ? `${scenario.apr?.toFixed(3)}%` : "N/A",
+      margin,
+      cursor,
+    )
+    drawLabelValue(
+      page,
+      helvetica,
+      "Term",
+      scenario.termMonths ? `${scenario.termMonths} months` : "N/A",
+      margin + 200,
+      cursor,
+    )
+    cursor -= 40
+  }
+
+  const firstName = (row.first_name as string) ?? ""
+  const lastName = (row.last_name as string) ?? ""
+  const customerName = firstName ? `${firstName} ${lastName}`.trim() : "N/A"
+  drawSectionHeader(page, helveticaBold, "Customer", margin, cursor)
+  cursor -= 24
+  drawLabelValue(page, helvetica, "Name", customerName, margin, cursor)
+  drawLabelValue(
+    page,
+    helvetica,
+    "Contact",
+    [row.customer_email as string, row.customer_phone as string]
+      .filter((value) => Boolean(value))
+      .join(" | ") || "N/A",
+    margin + 200,
+    cursor,
+  )
+  cursor -= 40
+
+  const notes = (row.notes as string) ?? ""
+  if (notes) {
+    drawSectionHeader(page, helveticaBold, "Notes", margin, cursor)
+    cursor -= 20
+    const lines = notes.match(/.{1,80}/g) ?? [notes]
+    for (const line of lines) {
+      page.drawText(line.trim(), { x: margin, y: cursor, size: 10, font: helvetica })
+      cursor -= 14
+    }
+  }
+
+  if (prepared) {
+    cursor -= 10
+    page.drawText(prepared, { x: margin, y: cursor, size: 9, font: helvetica, color: rgb(0.4, 0.4, 0.4) })
+  }
+
+  const pdfBytes = await doc.save()
+  const fileName = `deal-${dealId}-${scenario.scenarioType}-v${scenario.version}.pdf`
+  const metadata = {
+    scenarioType: scenario.scenarioType,
+    version: scenario.version,
+    preparedBy: preparedBy ?? null,
+  }
+
+  const insertResult = await query(
+    `INSERT INTO deal_documents (deal_id, scenario_id, document_type, file_name, pdf_data, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id, created_at`,
+    [dealId, scenarioId, documentType, fileName, Buffer.from(pdfBytes), metadata],
+  )
+
+  const base64 = Buffer.from(pdfBytes).toString("base64")
+  return {
+    document: {
+      id: insertResult.rows[0].id,
+      dealId,
+      scenarioId,
+      documentType,
+      fileName,
+      createdAt: insertResult.rows[0].created_at,
+      metadata,
+    },
+    pdf: base64,
+  }
+}
+
+export async function getDealDocumentBinary(dealId: string, documentId: string) {
+  const result = await query(
+    `SELECT file_name, pdf_data FROM deal_documents WHERE id = $1 AND deal_id = $2`,
+    [documentId, dealId],
+  )
+  if (result.rows.length === 0) {
+    throw new Error("Document not found")
+  }
+  return {
+    fileName: result.rows[0].file_name,
+    pdfData: result.rows[0].pdf_data as Buffer,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "next": "15.2.4",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.4",
+    "pdf-lib": "^1.17.1",
     "react": "^19",
     "react-day-picker": "8.10.1",
     "react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       next-themes:
         specifier: ^0.4.4
         version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: ^19
         version: 19.0.0
@@ -506,6 +509,12 @@ packages:
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2271,6 +2280,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2289,6 +2301,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -2753,6 +2768,9 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3152,6 +3170,14 @@ snapshots:
       fastq: 1.19.1
 
   '@panva/hkdf@1.2.1': {}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5112,6 +5138,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5126,6 +5154,13 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   pg-int8@1.0.1: {}
 
@@ -5663,6 +5698,8 @@ snapshots:
       typescript: 5.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 

--- a/scripts/setup-database.ts
+++ b/scripts/setup-database.ts
@@ -356,6 +356,120 @@ async function setupDatabase() {
     `)
     console.log("✅ Configurations table created.")
 
+    // Stores Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS stores (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name VARCHAR(255) NOT NULL,
+        contact_email VARCHAR(255),
+        contact_phone VARCHAR(50),
+        address TEXT,
+        settings JSONB DEFAULT '{}'::jsonb,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      );
+    `)
+    console.log("✅ Stores table created.")
+
+    // Store Deal Presets Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS store_deal_presets (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        store_id UUID REFERENCES stores(id) ON DELETE CASCADE,
+        preset_name VARCHAR(255) NOT NULL,
+        payload JSONB NOT NULL,
+        is_default BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE (store_id, preset_name)
+      );
+    `)
+    console.log("✅ Store deal presets table created.")
+
+    // Customers Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS customers (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        store_id UUID REFERENCES stores(id) ON DELETE CASCADE,
+        first_name VARCHAR(100) NOT NULL,
+        last_name VARCHAR(100) NOT NULL,
+        email VARCHAR(255),
+        phone VARCHAR(50),
+        profile JSONB DEFAULT '{}'::jsonb,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      );
+    `)
+    console.log("✅ Customers table created.")
+
+    // Customer Deal Presets Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS customer_deal_presets (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        customer_id UUID REFERENCES customers(id) ON DELETE CASCADE,
+        preset_name VARCHAR(255) NOT NULL,
+        payload JSONB NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE (customer_id, preset_name)
+      );
+    `)
+    console.log("✅ Customer deal presets table created.")
+
+    // Deals Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS deals (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        store_id UUID REFERENCES stores(id) ON DELETE CASCADE,
+        customer_id UUID REFERENCES customers(id) ON DELETE SET NULL,
+        title VARCHAR(255) NOT NULL,
+        vehicle JSONB DEFAULT '{}'::jsonb,
+        status VARCHAR(50) DEFAULT 'draft',
+        base_price NUMERIC(12, 2) NOT NULL DEFAULT 0,
+        notes TEXT,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      );
+    `)
+    console.log("✅ Deals table created.")
+
+    // Deal Scenarios Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS deal_scenarios (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        deal_id UUID REFERENCES deals(id) ON DELETE CASCADE,
+        scenario_type VARCHAR(20) NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        price NUMERIC(12, 2) NOT NULL,
+        down_payment NUMERIC(12, 2) DEFAULT 0,
+        term_months INTEGER,
+        apr NUMERIC(5, 3),
+        money_factor NUMERIC(8, 6),
+        residual_value NUMERIC(12, 2),
+        payment NUMERIC(12, 2),
+        fees JSONB DEFAULT '{}'::jsonb,
+        taxes JSONB DEFAULT '{}'::jsonb,
+        metadata JSONB DEFAULT '{}'::jsonb,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      );
+    `)
+    console.log("✅ Deal scenarios table created.")
+
+    // Deal Documents Table
+    await query(`
+      CREATE TABLE IF NOT EXISTS deal_documents (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        deal_id UUID REFERENCES deals(id) ON DELETE CASCADE,
+        scenario_id UUID REFERENCES deal_scenarios(id) ON DELETE SET NULL,
+        document_type VARCHAR(50) NOT NULL,
+        file_name VARCHAR(255) NOT NULL,
+        pdf_data BYTEA NOT NULL,
+        metadata JSONB DEFAULT '{}'::jsonb,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      );
+    `)
+    console.log("✅ Deal documents table created.")
+
     // Create indexes for better performance
     await query(`
       CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
@@ -365,6 +479,12 @@ async function setupDatabase() {
       CREATE INDEX IF NOT EXISTS idx_menus_parent_id ON menus(parent_id);
       CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id);
       CREATE INDEX IF NOT EXISTS idx_settings_user_id ON settings(user_id);
+      CREATE INDEX IF NOT EXISTS idx_stores_name ON stores(name);
+      CREATE INDEX IF NOT EXISTS idx_customers_store_id ON customers(store_id);
+      CREATE INDEX IF NOT EXISTS idx_deals_store_id ON deals(store_id);
+      CREATE INDEX IF NOT EXISTS idx_deals_customer_id ON deals(customer_id);
+      CREATE INDEX IF NOT EXISTS idx_deal_scenarios_deal_id ON deal_scenarios(deal_id);
+      CREATE INDEX IF NOT EXISTS idx_deal_documents_deal_id ON deal_documents(deal_id);
     `)
     console.log("✅ Indexes created.")
 


### PR DESCRIPTION
## Summary
- add persistent database tables for stores, customers, deals, scenarios, and deal documents
- implement server-side deal services and REST APIs with PDF generation using pdf-lib
- build a dashboard workspace for cash, finance, and lease scenarios with history, presets, and document downloads

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ee71908b24832c9ff5bb1062b0ac34